### PR TITLE
Fix http error 500 in TariffQueryController.Get when using yesterdat/today/tomorrow. Introduced when UTC'ing datetimes.

### DIFF
--- a/GridTariffAPI.lib/Controllers/v1/TariffQueryController.cs
+++ b/GridTariffAPI.lib/Controllers/v1/TariffQueryController.cs
@@ -82,8 +82,8 @@ namespace GridTariffApi.Lib.Controllers.v1
                 return BadRequest(validationErrorMsg);
             }
 
-            DateTime startDateTime = _serviceHelper.GetStartTime(tariffQueryRequest.Range, tariffQueryRequest.StartTime.Value.DateTime);
-            DateTime endDateTime = _serviceHelper.GetEndTime(tariffQueryRequest.Range, tariffQueryRequest.EndTime.Value.DateTime);
+            DateTime startDateTime = _serviceHelper.GetStartTime(tariffQueryRequest.Range, tariffQueryRequest.StartTime);
+            DateTime endDateTime = _serviceHelper.GetEndTime(tariffQueryRequest.Range, tariffQueryRequest.EndTime);
             TariffQueryResult tariffQueryResult = _tariffQueryService.QueryTariff(tariffQueryRequest.TariffKey, startDateTime, endDateTime);
             return Ok(tariffQueryResult);
         }
@@ -101,7 +101,7 @@ namespace GridTariffApi.Lib.Controllers.v1
                 return $"TariffType {tariffQueryModel.TariffKey} not found";
             }
 
-            DateTime startDateTime = _serviceHelper.GetStartTime(tariffQueryModel.Range, tariffQueryModel.StartTime.Value.DateTime);
+            DateTime startDateTime = _serviceHelper.GetStartTime(tariffQueryModel.Range, tariffQueryModel.StartTime);
             if (startDateTime < _gridTariffApiConfig.MinStartDateAllowedQuery)
             {
                 return $"Query before {_gridTariffApiConfig.MinStartDateAllowedQuery} not supported";


### PR DESCRIPTION
Fix http error 500 in TariffQueryController.Get when using yesterdat/today/tomorrow. Introduced when UTC'ing datetimes.