### PR TITLE
set interval of meteringpointsync to 12 hours to ensure we have enoug…

### DIFF
--- a/GridTariffAPI/Startup.cs
+++ b/GridTariffAPI/Startup.cs
@@ -148,7 +148,7 @@ namespace GridTariffApi
                 services.AddCronJob<MeteringPointTariffSynchronizer>(c =>
                 {
                     c.TimeZoneInfo = NorwegianTimeZoneInfo();
-                    c.CronExpression = @"0 0/1 * * *"; // every hour
+                    c.CronExpression = @"0 0/12 * * *"; // every hour
                 });
             }
 


### PR DESCRIPTION
…h time to perform fullsync of meteringpointtariff before next scheduled job starts.