### PR TITLE
bugfix.

### DIFF
--- a/GridTariffAPI.lib/Controllers/v1/TariffQueryController.cs
+++ b/GridTariffAPI.lib/Controllers/v1/TariffQueryController.cs
@@ -15,7 +15,7 @@ namespace GridTariffApi.Lib.Controllers.v1
 {
     [Produces(MediaTypeNames.Application.Json)]
     [ApiController]
-//    [Authorize]
+    [Authorize]
     [ApiVersion("1.0")]
     [Route("digin/api/{v:apiVersion}")]
     public class TariffQueryController : ControllerBase

--- a/GridTariffAPI.lib/Controllers/v1/TariffQueryController.cs
+++ b/GridTariffAPI.lib/Controllers/v1/TariffQueryController.cs
@@ -15,7 +15,7 @@ namespace GridTariffApi.Lib.Controllers.v1
 {
     [Produces(MediaTypeNames.Application.Json)]
     [ApiController]
-    [Authorize]
+//    [Authorize]
     [ApiVersion("1.0")]
     [Route("digin/api/{v:apiVersion}")]
     public class TariffQueryController : ControllerBase

--- a/GridTariffAPI.lib/Services/Helpers/IServiceHelper.cs
+++ b/GridTariffAPI.lib/Services/Helpers/IServiceHelper.cs
@@ -17,6 +17,6 @@ namespace GridTariffApi.Lib.Services.Helpers
         DateTimeOffset CreateLocaledDateTimeOffset(int year, int month, int day, int hour, int minute, int second);
         List<TimePeriod> GetMonthPeriods(DateTimeOffset fromDate, DateTimeOffset toDate, IReadOnlyList<int> months);
         DateTimeOffset GetStartOfNextMonth(DateTimeOffset fromDateLocaled);
-
+        public DateTimeOffset DecideEndOfDay(DateTimeOffset paramToDate, DateTimeOffset currentDateTime);
     }
 }

--- a/GridTariffAPI.lib/Services/Helpers/ServiceHelper.cs
+++ b/GridTariffAPI.lib/Services/Helpers/ServiceHelper.cs
@@ -215,5 +215,15 @@ namespace GridTariffApi.Lib.Services.Helpers
             }
             return true;
         }
+        public DateTimeOffset DecideEndOfDay(DateTimeOffset paramToDate, DateTimeOffset currentDateTime)
+        {
+            //middle of next day
+            var middleOfNextDay = currentDateTime.Date.AddHours(12).AddDays(1);
+
+            //next midnight and correct for DST change
+            var nextMidnight = CreateLocaledDateTimeOffset(middleOfNextDay.Year, middleOfNextDay.Month, middleOfNextDay.Day, 0, 0, 0);
+
+            return nextMidnight < paramToDate ? nextMidnight : paramToDate;
+        }
     }
 }

--- a/GridTariffAPI.lib/Services/TariffQueryService.cs
+++ b/GridTariffAPI.lib/Services/TariffQueryService.cs
@@ -601,7 +601,7 @@ namespace GridTariffApi.Lib.Services
 
 //next day and correct for DST change
                 var toDate = fromDate.AddDays(1) < paramToDate ? fromDate.AddDays(1) : paramToDate;
-                toDate = _serviceHelper.CreateLocaledDateTimeOffset(toDate.Year, toDate.Month, toDate.Day, 0, 0, 0);
+                toDate = _serviceHelper.CreateLocaledDateTimeOffset(toDate.Year, toDate.Month, toDate.Day, toDate.Hour, 0, 0);
 
                 dataAccumulator = await ProcessDayAsync(dataAccumulator, fromDate, toDate, hourSeasonIndex, tariffResolutionMinutes, isPublicHoliday, isWeekend);
                 fromDate = toDate;

--- a/GridTariffAPI.lib/Services/TariffQueryService.cs
+++ b/GridTariffAPI.lib/Services/TariffQueryService.cs
@@ -592,18 +592,16 @@ namespace GridTariffApi.Lib.Services
             List<Holiday> holidays,
             int tariffResolutionMinutes)
 
-        {
+        { 
             var fromDate = paramFromDate;
             while (fromDate.Ticks < paramToDate.Ticks)
             {
                 bool isPublicHoliday = IsPublicHoliday(holidays, fromDate);
                 bool isWeekend = IsWeekend(fromDate);
 
-//next day and correct for DST change
-                var toDate = fromDate.AddDays(1) < paramToDate ? fromDate.AddDays(1) : paramToDate;
-                toDate = _serviceHelper.CreateLocaledDateTimeOffset(toDate.Year, toDate.Month, toDate.Day, toDate.Hour, 0, 0);
-
+                DateTimeOffset toDate = _serviceHelper.DecideEndOfDay(paramToDate, fromDate);
                 dataAccumulator = await ProcessDayAsync(dataAccumulator, fromDate, toDate, hourSeasonIndex, tariffResolutionMinutes, isPublicHoliday, isWeekend);
+
                 fromDate = toDate;
             }
             return dataAccumulator;

--- a/GridTariffApi.Lib.Tests/Services/Helpers/ServiceHelperTests.cs
+++ b/GridTariffApi.Lib.Tests/Services/Helpers/ServiceHelperTests.cs
@@ -334,5 +334,44 @@ namespace GridTariffApi.Lib.Tests.Services.Helpers
             toDate = DateTimeOffset.UtcNow.AddDays(2);
             Assert.False(_serviceHelper.TimePeriodIsIncludingLocaleToday(fromDate, toDate));
         }
+        [Fact]
+        public void DecideEndOfDayTests()
+        {
+            Setup();
+            //no DST change, before mid day
+            var currentDateTime1 = new DateTimeOffset(2022, 06, 01, 1, 0, 0, new TimeSpan(2, 0, 0));
+            var paramToDate1 = new DateTimeOffset(2022, 12, 01, 1, 0, 0, new TimeSpan(1, 0, 0));
+            var expected1 = new DateTimeOffset(2022, 06, 02, 0, 0, 0, new TimeSpan(2, 0, 0));
+            var retVal1 = _serviceHelper.DecideEndOfDay(paramToDate1, currentDateTime1);
+            Assert.Equal(expected1,retVal1);
+
+            //no DST change, after mid dat
+            var currentDateTime2 = new DateTimeOffset(2022, 06, 01, 18, 0, 0, new TimeSpan(2, 0, 0));
+            var retVal2= _serviceHelper.DecideEndOfDay(paramToDate1, currentDateTime2);
+            Assert.Equal(expected1, retVal2);
+
+            //no DST change, at midnight
+            var currentDateTime3 = new DateTimeOffset(2022, 06, 01, 0, 0, 0, new TimeSpan(2, 0, 0));
+            var retVal3 = _serviceHelper.DecideEndOfDay(paramToDate1, currentDateTime3);
+            Assert.Equal(expected1, retVal3);
+
+            //picking least of next day and todate
+            var paramToDate4 = new DateTimeOffset(2022, 6, 01, 18, 0, 0, new TimeSpan(2, 0, 0));
+            var retVal4 = _serviceHelper.DecideEndOfDay(paramToDate4, currentDateTime3);
+            Assert.Equal(paramToDate4, retVal4);
+
+            //to DST within timeperiod
+            var currentDateTime5 = new DateTimeOffset(2022, 03, 27, 00, 0, 0, new TimeSpan(1, 0, 0));
+            var expected5 = new DateTimeOffset(2022, 03, 28, 0, 0, 0, new TimeSpan(2, 0, 0));
+            var retVal5 = _serviceHelper.DecideEndOfDay(paramToDate4, currentDateTime5);
+            Assert.Equal(expected5, retVal5);
+
+            //to no DST within timperiod
+            var currentDateTime6 = new DateTimeOffset(2022, 10, 30, 00, 0, 0, new TimeSpan(2, 0, 0));
+            var expected6 = new DateTimeOffset(2022, 10, 31, 0, 0, 0, new TimeSpan(1, 0, 0));
+            var retVal6 = _serviceHelper.DecideEndOfDay(paramToDate1, currentDateTime6);
+            Assert.Equal(expected6, retVal6);
+
+        }
     }
 }


### PR DESCRIPTION
when iterating days in month.
when correcting for DST the hour-part was truncated. This created loop when queryparameter todate was not at end/beginning of a day.